### PR TITLE
1.15 output slot fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Growthcraft Traffer](https://github.com/GrowthcraftCE/Growthcraft-1.15-Trapper/blob/release/src/main/resources/growthcraft_fishtrap_logo.png)
 
 # Growthcraft 5 for Minecraft 1.15.2 (Forge)
-[![Growthcraft Version](https://img.shields.io/badge/Growthcraft-5.0.0-orange.svg)](https://github.com/GrowthcraftCE/Growthcraft-1.15)
+[![Growthcraft Version](https://img.shields.io/badge/Growthcraft-5.1.0-orange.svg)](https://github.com/GrowthcraftCE/Growthcraft-1.15)
 [![](http://cf.way2muchnoise.eu/versions/growthcraft-community-edition_latest.svg)](https://minecraft.curseforge.com/projects/growthcraft-community-edition/)
 [![](http://cf.way2muchnoise.eu/short_growthcraft-community-edition.svg)](https://minecraft.curseforge.com/projects/growthcraft-community-edition/)
 [![Forge Version](https://img.shields.io/badge/Minecraft%20Forge-31.2.0-yellow.svg)](http://files.minecraftforge.net/maven/net/minecraftforge/forge/index_1.15.2.html)
@@ -20,5 +20,5 @@ To Be Written
 
 ### Growthcraft Trapper 5 (Minecraft 1.15.2)
 End of Support: TBD
-Latest Version: 5.0.0
+Latest Version: 5.1.0
 Stable Version: TBD

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.daemon=false
 # | | Bug Fix / Maintenance Release
 # | Feature Release
 # Product Release
-growthcraft_version=5.0.0
+growthcraft_version=5.1.0
 # Changing these values prompts a Product release
 minecraft_version=1.15.2
 minecraft_version_short=1.15

--- a/src/main/java/growthcraft/trapper/init/config/GrowthcraftTrapperConfig.java
+++ b/src/main/java/growthcraft/trapper/init/config/GrowthcraftTrapperConfig.java
@@ -19,7 +19,15 @@ public class GrowthcraftTrapperConfig {
     public static final ForgeConfigSpec SERVER;
     public static final ForgeConfigSpec CLIENT;
 
+    private static ForgeConfigSpec.BooleanValue unlockFishtrapOutputSlots;
+
     static {
+        SERVER_BUILDER.comment(String.format("General configuration for %s", Reference.NAME)).define(
+                "version", Reference.VERSION);
+
+        unlockFishtrapOutputSlots =
+                SERVER_BUILDER.comment("Set to true to unlock the Fishtrap output slots.").define("fishtrap.unlockOutputSlots", false);
+
         SERVER = SERVER_BUILDER.build();
         CLIENT = CLIENT_BUILDER.build();
     }
@@ -37,6 +45,14 @@ public class GrowthcraftTrapperConfig {
 
         fileConfig.load();
         configSpec.setConfig(fileConfig);
+    }
+
+    public static void initConfig(ForgeConfigSpec.Builder server, ForgeConfigSpec.Builder client) {
+
+    }
+
+    public static boolean fishtrapOutputSlotsUnlocked() {
+        return unlockFishtrapOutputSlots.get();
     }
 
 }

--- a/src/main/java/growthcraft/trapper/lib/common/handler/TrapItemStackHandler.java
+++ b/src/main/java/growthcraft/trapper/lib/common/handler/TrapItemStackHandler.java
@@ -16,6 +16,9 @@ public class TrapItemStackHandler extends ItemStackHandler {
     public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
         // TODO: Handle slot 0 as the bait slot only.
         //  User should not be able to insert into slot 1 through 5
+        if(slot >= 1 && slot <= 5){
+            return false;
+        }
         return super.isItemValid(slot, stack);
     }
 

--- a/src/main/java/growthcraft/trapper/lib/common/inventory/ContainerFishtrap.java
+++ b/src/main/java/growthcraft/trapper/lib/common/inventory/ContainerFishtrap.java
@@ -33,8 +33,10 @@ public class ContainerFishtrap extends Container {
         // OutPut Slots
         int startX = 44;
         int startY = 20;
-        for (int i = 0; i < 6; i++) {
-            Slot slot = new Slot(tileEntityFishtrap, index, startX + (i * slotSizePlus2), startY);
+        this.addSlot(new Slot(tileEntityFishtrap, index, startX , startY));
+        index++;
+        for (int i = 1; i < 6; i++) {
+            Slot slot = new FishtrapOutputSlot(tileEntityFishtrap, index, startX + (i * slotSizePlus2), startY);
             this.addSlot(slot);
             index++;
         }

--- a/src/main/java/growthcraft/trapper/lib/common/inventory/ContainerFishtrap.java
+++ b/src/main/java/growthcraft/trapper/lib/common/inventory/ContainerFishtrap.java
@@ -33,9 +33,7 @@ public class ContainerFishtrap extends Container {
         // OutPut Slots
         int startX = 44;
         int startY = 20;
-        this.addSlot(new Slot(tileEntityFishtrap, index, startX , startY));
-        index++;
-        for (int i = 1; i < 6; i++) {
+        for (int i = 0; i < 6; i++) {
             Slot slot = new FishtrapOutputSlot(tileEntityFishtrap, index, startX + (i * slotSizePlus2), startY);
             this.addSlot(slot);
             index++;

--- a/src/main/java/growthcraft/trapper/lib/common/inventory/FishtrapOutputSlot.java
+++ b/src/main/java/growthcraft/trapper/lib/common/inventory/FishtrapOutputSlot.java
@@ -1,6 +1,6 @@
 package growthcraft.trapper.lib.common.inventory;
 
-import net.minecraft.entity.player.PlayerEntity;
+import growthcraft.trapper.init.config.GrowthcraftTrapperConfig;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.container.Slot;
 import net.minecraft.item.ItemStack;
@@ -11,8 +11,9 @@ public class FishtrapOutputSlot extends Slot {
         super(inventoryIn, slotIndex, xPosition, yPosition);
     }
 
+    @Override
     public boolean isItemValid(ItemStack stack){
-        return false;
+        return GrowthcraftTrapperConfig.fishtrapOutputSlotsUnlocked();
     }
 
 }

--- a/src/main/java/growthcraft/trapper/lib/common/inventory/FishtrapOutputSlot.java
+++ b/src/main/java/growthcraft/trapper/lib/common/inventory/FishtrapOutputSlot.java
@@ -1,0 +1,18 @@
+package growthcraft.trapper.lib.common.inventory;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.container.Slot;
+import net.minecraft.item.ItemStack;
+
+public class FishtrapOutputSlot extends Slot {
+
+    public FishtrapOutputSlot(IInventory inventoryIn, int slotIndex, int xPosition, int yPosition){
+        super(inventoryIn, slotIndex, xPosition, yPosition);
+    }
+
+    public boolean isItemValid(ItemStack stack){
+        return false;
+    }
+
+}

--- a/src/main/java/growthcraft/trapper/lib/common/tileentity/TileEntityFishtrap.java
+++ b/src/main/java/growthcraft/trapper/lib/common/tileentity/TileEntityFishtrap.java
@@ -2,6 +2,7 @@ package growthcraft.trapper.lib.common.tileentity;
 
 import growthcraft.trapper.init.GrowthcraftTrapperTileEntities;
 import growthcraft.trapper.lib.common.block.FishtrapBlock;
+import growthcraft.trapper.lib.common.handler.TrapItemStackHandler;
 import growthcraft.trapper.lib.common.inventory.ContainerFishtrap;
 import growthcraft.trapper.lib.utils.BlockStateUtils;
 import growthcraft.trapper.lib.utils.TickUtils;

--- a/src/main/java/growthcraft/trapper/shared/Reference.java
+++ b/src/main/java/growthcraft/trapper/shared/Reference.java
@@ -5,7 +5,7 @@ public class Reference {
     public static final String NAME = "Growthcraft Trapper";
     public static final String NAME_SHORT = "trapper";
 
-    public static final String VERSION = growthcraft.trapper.shared.Reference.VERSION;
+    public static final String VERSION = "5.1.0";
 
     private Reference() { /* Prevent default public constructor */ }
 }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -4,7 +4,7 @@ issueTrackerURL = "https://github.com/GrowthcraftCE/Growthcraft-1.15-Trapper/iss
 
 [[mods]]
 modId = "growthcraft_trapper"
-version = "5.0.0"
+version = "5.1.0"
 displayName = "Growthcraft"
 updateJSONURL = "https://raw.githubusercontent.com/GrowthcraftCE/Growthcraft-Updates/master/growthcraft-trapper-versions.json"
 displayURL = "https://github.com/GrowthcraftCE/Growthcraft-1.15-Trapper/wiki"


### PR DESCRIPTION
Fishtrap Output slots are now locked for input by default.
Added a configuration option for unlocking the fishtrap output slots.